### PR TITLE
OPS-4699 - Prepare mongo for SSL connections

### DIFF
--- a/django_short_urls/local_settings.py.erb
+++ b/django_short_urls/local_settings.py.erb
@@ -12,13 +12,7 @@ ADMINS = (
 
 SERVER_EMAIL = "root@work4labs.com"
 
-MONGOENGINE = {
-    'db': '<%= @creds["db"]["name"] %>',
-    'host': '<%= @creds["db"]["host"] %>',
-    'port': <%= @creds["db"]["port"] %>,
-    'username': '<%= @creds["db"]["username"] %>',
-    'password': '<%= @creds["db"]["password"] %>'
-}
+MONGO_URI = '<%= @creds["mongo_uri"] %>'
 
 ALLOWED_HOSTS = ['.workfor.us']
 

--- a/django_short_urls/local_settings.tpl.py
+++ b/django_short_urls/local_settings.tpl.py
@@ -12,7 +12,7 @@ ADMINS = (
 
 SERVER_EMAIL = "root@work4labs.com"
 
-MONGO_URI = 'mongodb://work4labs:work4labs@localhost:27017/work4labs'
+MONGO_URI = 'mongodb://localhost:27017/work4labs'
 
 ALLOWED_HOSTS = ['.workfor.us']
 

--- a/django_short_urls/local_settings.tpl.py
+++ b/django_short_urls/local_settings.tpl.py
@@ -12,7 +12,7 @@ ADMINS = (
 
 SERVER_EMAIL = "root@work4labs.com"
 
-MONGO_URI = 'mongodb://work4labs@work4labs@localhost:27017/work4labs'
+MONGO_URI = 'mongodb://work4labs:work4labs@localhost:27017/work4labs'
 
 ALLOWED_HOSTS = ['.workfor.us']
 

--- a/django_short_urls/local_settings.tpl.py
+++ b/django_short_urls/local_settings.tpl.py
@@ -12,13 +12,7 @@ ADMINS = (
 
 SERVER_EMAIL = "root@work4labs.com"
 
-MONGOENGINE = {
-    'db': 'work4labs',
-    'host': 'localhost',
-    'port': 27017,
-    'username': 'work4labs',
-    'password': 'work4labs'
-}
+MONGO_URI = 'mongodb://work4labs@work4labs@localhost:27017/work4labs'
 
 ALLOWED_HOSTS = ['.workfor.us']
 

--- a/django_short_urls/settings.py
+++ b/django_short_urls/settings.py
@@ -82,7 +82,7 @@ if not DEBUG:  # pragma: no cover
 #############
 
 try:
-    mongoengine.connect(read_preference=ReadPreference.PRIMARY_PREFERRED, **MONGOENGINE)
+    mongoengine.connect(host=MONGO_URI, read_preference=ReadPreference.PRIMARY_PREFERRED)
 
     SERVICE_UNAVAILABLE = False
 except mongoengine.connection.ConnectionError, err:  # pragma: no cover


### PR DESCRIPTION
:arrow_upper_left: https://work4labs.atlassian.net/browse/OPS-4699 

-----

Technically shouldn't change anything for us in production, we're already using a mongodb URI in the `host` parameter
cf. note in http://docs.mongoengine.org/guide/connecting.html#connecting-to-mongodb