### PR TITLE
BAT-8659 shortener × gunicorn

### DIFF
--- a/django_short_urls/gunicorn_config.py
+++ b/django_short_urls/gunicorn_config.py
@@ -1,5 +1,10 @@
-# -*- coding: utf-8 -
-# https://docs.gunicorn.org/en/19.9.0/settings.html
+# -*- coding: utf-8 -*-
+"""
+Defines the shortener / django-short-urls settings for gunicorn.
+https://docs.gunicorn.org/en/19.9.0/settings.html
+"""
+# Sorry pylint, I know you don't like lowercase constants, but...
+# pylint: disable=invalid-name
 
 import os
 

--- a/django_short_urls/gunicorn_config.py
+++ b/django_short_urls/gunicorn_config.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -
+# https://docs.gunicorn.org/en/19.9.0/settings.html
+
+import os
+
+# GENERAL / TUNING
+proc_name = "shortener"
+
+# Do start gunicorn from the virtualenv to make all 3rd-party pkgs available
+pythonpath = os.path.dirname(os.path.abspath(__file__))
+
+bind = "127.0.0.1:8000"
+
+# Tuning: see http://docs.gunicorn.org/en/19.9.0/design.html
+# Use async gevent workers; doesn't hurt, may help a little with DB I/O
+worker_class = "gevent"
+
+# Pass the numbers of `workers` using the WEB_CONCURRENCY envvar
+threads = 0
+max_requests = 100000
+max_requests_jitter = 100
+
+timeout = 10
+
+
+# MONITORING
+statsd_host = "localhost:8125"
+statsd_prefix = ""
+

--- a/django_short_urls/gunicorn_config.py
+++ b/django_short_urls/gunicorn_config.py
@@ -26,4 +26,3 @@ timeout = 10
 # MONITORING
 statsd_host = "localhost:8125"
 statsd_prefix = ""
-

--- a/django_short_urls/tests/gunicorn_config_test.py
+++ b/django_short_urls/tests/gunicorn_config_test.py
@@ -1,0 +1,11 @@
+# coding=utf-8
+# Micro test for coverage, ensure config can be loaded
+
+from django_app.test import PyW4CTestCase
+
+from django_short_urls import gunicorn_config
+
+
+class GunicornConfigTestCase(PyW4CTestCase):
+    def test(self):
+        self.assertEqual(gunicorn_config.threads, 0)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@
 -r ./vendor/pywork4core/web/requirements.txt
 
 dogstatsd-python
+gevent==1.3.7
+gunicorn==19.9.0

--- a/vendor/pywork4core/config/coverage.rc
+++ b/vendor/pywork4core/config/coverage.rc
@@ -2,11 +2,11 @@
 
 branch = true
 data_file = temp/coverage.data
-omit = venv*,*django_app/tests*,*/gunicorn_config.py
+omit = venv*,*django_app/tests*
 
 [report]
 
-omit=venv*,*django_app/tests*,*/gunicorn_config.py,vendor/pywork4core/manage.py,vendor/pywork4core/django_app/settings.py
+omit=venv*,*django_app/tests*,vendor/pywork4core/manage.py,vendor/pywork4core/django_app/settings.py
 
 [html]
 directory = temp/coverage_html

--- a/vendor/pywork4core/config/coverage.rc
+++ b/vendor/pywork4core/config/coverage.rc
@@ -2,11 +2,11 @@
 
 branch = true
 data_file = temp/coverage.data
-omit = venv*,*django_app/tests*
+omit = venv*,*django_app/tests*,*/gunicorn_config.py
 
 [report]
 
-omit=venv*,*django_app/tests*,vendor/pywork4core/manage.py,vendor/pywork4core/django_app/settings.py
+omit=venv*,*django_app/tests*,*/gunicorn_config.py,vendor/pywork4core/manage.py,vendor/pywork4core/django_app/settings.py
 
 [html]
 directory = temp/coverage_html


### PR DESCRIPTION
To be integrated with our existing gunicorn deployments
(i.e. start from venv, pass config path, pass `WEB_CONCURRENCY` envvar)